### PR TITLE
Implement auto refresh access tokens 

### DIFF
--- a/API/fwapp.py
+++ b/API/fwapp.py
@@ -2,7 +2,7 @@ from API import app
 from API.services.DBManipulation import *
 from API.services.AuthServices import *
 from .models.RequestBodySchema import FormData
-from .models.AuthSchema import UserAuth, TokenSchema, UserOut
+from .models.AuthSchema import UserAuth, TokenSchema, UserOut, UseRefreshToken
 from .utils.JWTBearer import JWTBearer
 from .utils import scopes
 from .core.ExceptionHandlers import *
@@ -18,7 +18,6 @@ app.mount("/static", StaticFiles(directory="API/static"), name="static")
 
 
 @app.get("/", tags=["Home"])
-@app.get("/home", tags=["Home"])
 def home(request: Request):
     return templates.TemplateResponse("home.html", context={"request": request})
 
@@ -183,7 +182,13 @@ async def login(form_data: UserAuth = Depends()):
     return tokens
 
 
-@app.get('/me', summary='Get details of currently logged in user', response_model=UserOut, tags=["SessionInfo"])
-async def get_me(user: str = Depends(JWTBearer())):
-    data = get_current_user_credentials(user)
-    return data
+@app.post("/auth/use_refresh_token", summary="generate a fresh pair of access tokens using refresh tokens",
+          response_model=TokenSchema, tags=["Auth"], dependencies=[Depends(JWTBearer())])
+async def auth_use_refresh_token(existing_tokens: UseRefreshToken):
+    return handle_refresh_token_access(existing_tokens.refresh_access_token)
+
+
+# @app.get('/me', summary='Get details of currently logged in user', response_model=UserOut, tags=["SessionInfo"])
+# async def get_me(user: str = Depends(JWTBearer())):
+#     data = get_current_user_credentials(user)
+#     return data

--- a/API/fwapp.py
+++ b/API/fwapp.py
@@ -140,7 +140,7 @@ def api_get_individual_data(respondents_id: str, user_credentials: str = Depends
     return response_result
 
 
-@app.post('/signup', summary="Create new user", response_model=FrontendResponseModel, tags=["Auth"],
+@app.post('/auth/signup', summary="Create new user", response_model=FrontendResponseModel, tags=["Auth"],
           dependencies=[Depends(JWTBearer())])
 async def create_user(data: UserAuth, user_credentials: str = Depends(JWTBearer())):
     response_result = {
@@ -170,7 +170,7 @@ async def create_user(data: UserAuth, user_credentials: str = Depends(JWTBearer(
     return response_result
 
 
-@app.post('/login', summary="Log-in to the user account", response_model=TokenSchema, tags=["Auth"])
+@app.post('/auth/login', summary="Log-in to the user account", response_model=TokenSchema, tags=["Auth"])
 async def login(form_data: UserAuth = Depends()):
     tokens = {
         "status": "Internal Server Error 505",
@@ -188,7 +188,7 @@ async def auth_use_refresh_token(existing_tokens: UseRefreshToken):
     return handle_refresh_token_access(existing_tokens.refresh_access_token)
 
 
-# @app.get('/me', summary='Get details of currently logged in user', response_model=UserOut, tags=["SessionInfo"])
+# @app.get('/auth/me', summary='Get details of currently logged in user', response_model=UserOut, tags=["SessionInfo"])
 # async def get_me(user: str = Depends(JWTBearer())):
 #     data = get_current_user_credentials(user)
 #     return data

--- a/API/models/AuthSchema.py
+++ b/API/models/AuthSchema.py
@@ -1,12 +1,13 @@
 from pydantic import BaseModel, Field
 
+
 class TokenSchema(BaseModel):
     status: str
     access_token: str
     refresh_token: str
     role: str
-    
-    
+
+
 class TokenPayload(BaseModel):
     sub: str = None
     exp: int = None
@@ -15,10 +16,14 @@ class TokenPayload(BaseModel):
 class UserAuth(BaseModel):
     AADHAR_NO: str = Field(..., description="user Aadhar number")
     password: str = Field(..., min_length=5, max_length=24, description="user password")
-    village_name:str = Field(..., description="user village name")
-    role:str=Field(..., description="user role")
-    
+    village_name: str = Field(..., description="user village name")
+    role: str = Field(..., description="user role")
+
 
 class UserOut(BaseModel):
     AADHAR: str
     village_name: str
+
+
+class UseRefreshToken(BaseModel):
+    refresh_access_token: str

--- a/API/services/AuthServices.py
+++ b/API/services/AuthServices.py
@@ -109,3 +109,7 @@ def get_role(token: str) -> str:
     token_data = TokenPayload(**payload)
     role = token_data.sub.split("_")[1]
     return role
+
+
+def handle_refresh_token_access(token: str) -> TokenSchema:
+    return Auth.generate_access_tokens_from_refresh_tokens(token)

--- a/tests/login_utils.py
+++ b/tests/login_utils.py
@@ -3,7 +3,7 @@ import requests
 BASE_URL = "https://ubaformapi-dlzqw1gcl-fastapis-build.vercel.app"
 
 def get_access_token(data):
-    url = BASE_URL + "/login"
+    url = BASE_URL + "/auth/login"
     headers={
         "accept":"application/json",
    } 

--- a/tests/login_utils.py
+++ b/tests/login_utils.py
@@ -1,6 +1,6 @@
 import requests
 
-BASE_URL = "https://ubaformapi-dlzqw1gcl-fastapis-build.vercel.app"
+BASE_URL = "https://ubaformapi-7hic1hafd-fastapis-build.vercel.app"
 
 def get_access_token(data):
     url = BASE_URL + "/auth/login"

--- a/tests/test_signups.py
+++ b/tests/test_signups.py
@@ -7,7 +7,7 @@ from login_utils import get_access_token, BASE_URL
 
   #only admin can signup new users  
 class MySignupTestCase(unittest.TestCase):
-    url= BASE_URL + "/signup"
+    url= BASE_URL + "/auth/signup"
     signincred = {
         "AADHAR_NO": f"{os.environ['ADMIN_ID']}",
         "password": f"{os.environ['ADMIN_PWD']}",


### PR DESCRIPTION
Closes #55 

Add functionality to grant a fresh pair of access tokens with the help of valid refresh tokens. 

> The user's data would be lost if the access token gets expired when the user is entering the data. Rather than increasing the access token's expiration time which is a potential security threat, refresh tokens will help the user get a better authentication experience.