### PR TITLE
Fix Schema bug and typo

### DIFF
--- a/API/models/EDAResponseSchema.py
+++ b/API/models/EDAResponseSchema.py
@@ -49,7 +49,7 @@ class _3_FamilyInformation(BaseModel):
     name: str
     age: int
     sex: str
-    martial_status: str
+    marital_status: str
     education: str
     schooling_status: str
     AADHAR_No: str

--- a/API/models/RequestBodySchema.py
+++ b/API/models/RequestBodySchema.py
@@ -41,7 +41,7 @@ class _3_FamilyInformation(BaseModel):
     name: str
     age: int
     sex: str
-    martial_status: str
+    marital_status: str
     education: str
     schooling_status: str
     AADHAR_No: str
@@ -169,7 +169,7 @@ class FormData(BaseModel):
     agri_inputs: _9_AgriculturalInputs
 
     # agricultural products
-    agri_products: _10_AgriculturalProductsNormalYear
+    agri_products: Union[List[_10_AgriculturalProductsNormalYear], Tuple[_10_AgriculturalProductsNormalYear]]
 
     # livestock numbers
     livestock_nos: _11_LivestockNumbers

--- a/API/services/DBManipulation.py
+++ b/API/services/DBManipulation.py
@@ -111,9 +111,13 @@ def commit_to_db(response_result: dict, form_data: FormData)->Union[InsertOneRes
     DBQueries.insert_to_database(db, collection_names['ai'], data)
 
     # agri products
-    data = form_data.agri_products.dict()
-    data['__id'] = fid
-    DBQueries.insert_to_database(db, collection_names['ap'], data)
+    data = form_data.agri_products
+    data = [agri_prods.dict() for agri_prods in data]
+    [indiv_crop.update({"__id": fid}) for indiv_crop in data]
+    DBQueries.insert_to_database(db, collection_names['fi'], data)
+
+    # data['__id'] = fid
+    # DBQueries.insert_to_database(db, collection_names['ap'], data)
 
     # livestock nums
     data = form_data.livestock_nos.dict()


### PR DESCRIPTION
- `agri_prod` is now expected to be of type List[Dict] instead of Dict.
- Changed the method to extract the data from `agri_prod` to adapt to changes in the schema.
- Fixed EDAResponse Schema hence `agri_prod` is now expected to be of type List[Dict] instead of Dict.
- Fixed typos in  the `RequestBody` and `EDASchema`(martial_status --> marital_status)